### PR TITLE
fix: Decrypt content for password-protected downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -352,11 +352,14 @@ def download(url_id):
 
     if passwd and request.method != "POST":
         return render_template("passwd.html", url_id=url_id)
+    # This is the new, corrected code
     elif request.method == "POST":
         clip_passwd = request.form.get("clip_passwd")
             
         if check_password_hash(passwd, clip_passwd):
-            return Response(text, mimetype='text/plain',headers={'Content-disposition': f'attachment; filename={name}'})
+            # FIX: Decrypt the content before sending it in the response.
+            decrypted_text = decrypt(data[0]["clip_text"], clip_passwd).decode('utf-8')
+            return Response(decrypted_text, mimetype='text/plain',headers={'Content-disposition': f'attachment; filename={name}'})
         else:
             return render_template("passwd.html", error="Incorrect Password!", url_id=url_id)
  


### PR DESCRIPTION
### Description

This pull request resolves the critical bug where password-protected (encrypted) clips were being downloaded as raw ciphertext instead of their original, decrypted plaintext content. This made the download feature non-functional for any clip with End-to-End Encryption enabled.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- Modified the `download` function in `app.py`.
- The function now correctly calls the `decrypt()` utility on the clip's content after a successful password check.
- The decrypted content is then decoded to UTF-8 before being sent as a file in the HTTP response.

### How Has This Been Tested?
I have tested this fix locally by performing the following steps:
1. Created a new password-protected clip with sample text.
2. Navigated to the clip's page and used the "Download" feature.
3. Entered the correct password when prompted.
4. Opened the downloaded file and verified that it contained the original, readable plaintext.

This change successfully restores the expected functionality.

Closes #51 
[Screencast From 2025-10-03 18-54-34.webm](https://github.com/user-attachments/assets/97e85299-0f89-475b-b221-0eef8605314e)
