### PR TITLE
Added copy-to-clipboard button

### DIFF
--- a/templates/clip.html
+++ b/templates/clip.html
@@ -54,10 +54,12 @@
                         <textarea name="clip_text" id="clip_text" class="w-full mt-4 bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap" rows="4" oninput="this.style.height = 'auto'; let min = 8 * 16; let max = 30 * 16; let scrh = this.scrollHeight; if (scrh < min) { this.style.height = min + 'px'; } else if (scrh > max) { this.style.height = max + 'px'; } else { this.style.height = scrh + 'px'; } ">{{ text }}</textarea>
                         <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Update</button>
                     </form>
+                    <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" onclick="navigator.clipboard.writeText(document.getElementById('clip_text').value); alert('Text Copied!');">Copy Text</button>
                     {% else %}
                         <pre>
                         <code name="clip_text" class="w-full bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap">{{ text }}</code>
                         </pre>
+                        <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" onclick="navigator.clipboard.writeText(document.querySelector('code[name=clip_text]').innerText); alert('Text Copied!');">Copy Text</button>
                     {% endif %}
                     </pre>
                 </div>


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: "Added copy-to-clipboard button "
---

## Description
This PR adds a “Copy to Clipboard” button to the clip page in ClipBin. Users can now easily copy the clip content directly from the page, whether the clip is editable or read-only.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):

## How Has This Been Tested?

Manual testing in the browser:

- Opened a clip (both editable and non-editable).
- Clicked the Copy Text button.
- Pasted the copied content in a text editor → verified it matches the original clip text.

Copy URL button:

- Clicked the Copy URL button.
- Pasted the URL in a new tab → verified it navigates to the same clip.

Cross-browser verification:

- Tested in Chrome, Firefox, and Edge → confirmed the clipboard functionality works as expected.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
<img width="1450" height="690" alt="image" src="https://github.com/user-attachments/assets/250d92b1-44e6-4e6d-a41b-dbdc76af0c35" />


## Additional Notes:

Ref #8 
