### PR TITLE
fix: Prevent non-owners from editing clips

### DIFF
--- a/additional.py
+++ b/additional.py
@@ -95,6 +95,8 @@ def encrypt(data: bytes, passwd: str):
 
 # Decrypt Function
 def decrypt(encrypted_data: bytes, passwd: str):
+    if isinstance(encrypted_data, str):
+        encrypted_data = encrypted_data.encode("latin-1")
     salt = encrypted_data[:16]
     nonce = encrypted_data[16:28]
     cipher = encrypted_data[28:]

--- a/templates/clip.html
+++ b/templates/clip.html
@@ -42,14 +42,14 @@
                 <p class="leading-7 text-l text-white-400 w-auto text-wrap items-center">
                     <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/download/{{ url_id }}">Download as {{ ext }}</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/">Create Another</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/{{ url_id }}/raw">View Raw</a>
                 </p>
-                {% if edit and dat[0] == False %}
+                {% if edit and not is_owner %}
                 <br>
-                <p class="leading-7 text-l text-white-400 mt-2">This Clip can be editted by the Owner.</p>
+                <p class="leading-7 text-l text-white-400 mt-2">This clip is editable by its owner.</p>
                 {% endif %}
             </div>
             <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
-                    {% if edit and dat[0] == True %}
+                    {% if edit and is_owner %}
                     <form action="/update/{{ url_id }}" method="post">
                         <textarea name="clip_text" id="clip_text" class="w-full mt-4 bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap" rows="4" oninput="this.style.height = 'auto'; let min = 8 * 16; let max = 30 * 16; let scrh = this.scrollHeight; if (scrh < min) { this.style.height = min + 'px'; } else if (scrh > max) { this.style.height = max + 'px'; } else { this.style.height = scrh + 'px'; } ">{{ text }}</textarea>
                         <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Update</button>


### PR DESCRIPTION
This pull request resolves an issue where the user interface would incorrectly display an editable text area and an "Update" button for any logged-in user viewing a clip marked as "Editable," even if they were not the owner.

While the backend already prevented unauthorized updates, this change ensures the frontend UI accurately reflects the user's permissions, preventing user confusion.

### Changes Made:

 #### app.py:
    Updated the clip view to perform an ownership check by verifying the logged-in user_id against the clip's owner in the clipRef table.
    Passed a new is_owner boolean to the clip.html template.
    Modified the update function to prevent editing password-protected clips, which avoids a data corruption bug where plaintext would overwrite encrypted content.

#### templates/clip.html:
      Updated the template logic to use the new is_owner variable, ensuring the editing controls are only rendered for the actual clip owner.

#### additional.py:
      Made the decrypt function more robust by handling cases where encrypted data was incorrectly read from the database as a string, preventing a TypeError.

This fix ensures a more intuitive and secure user experience.

#### Screenrec: 
[Screencast From 2025-10-07 17-33-40.webm](https://github.com/user-attachments/assets/42357562-2e06-4f07-8c93-0915103bb7f4)


Related Issue: Closes #59