### PR TITLE
Fix encrypted clip corruption on update

### DIFF
--- a/app.py
+++ b/app.py
@@ -333,6 +333,7 @@ def clip(clip_url_id):
                     update=updated,
                     time_left=time_left,
                     ext=ext,
+                    passwd2=passwd,
                     dat=loginData(),
                 )
             else:

--- a/app.py
+++ b/app.py
@@ -471,11 +471,11 @@ def update(url_id):
                 flash("No content submitted")
                 return redirect(f"/{url_id}")
 
-            new_text = request.form.get("clip_text").strip()
+            new_text = str(request.form.get("clip_text")).strip()
 
             if clip_pwd:
 
-                clip_pass = request.form.get("clip_passwd")
+                clip_pass = str(request.form.get("clip_passwd"))
 
                 if not clip_pass:
                     flash("Password required to update this protected clip.")

--- a/templates/clip.html
+++ b/templates/clip.html
@@ -20,10 +20,10 @@
             {% endif %}
             <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
-                    <label for="clip_passwd" class="leading-7 text-lg text-gray-400">Enter Password</label>
+                    <label for="clip_passwd" class="leading-7 text-gray-400">Enter Password</label>
                     <form action="/{{ url_id }}" method="post">
                         <input type="password" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-800 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
-                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Go</button>
+                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded" type="submit">Go</button>
                     </form>
                 </div>
             </div>
@@ -36,18 +36,18 @@
         <div class="container px-5 py-24 mx-auto">
             <div class="flex flex-col text-center w-full mb-12">
                 <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-white">{{ name }}</h1>
-                <p class="leading-7 text-lg text-white-400">ID: {{ url_id }} <button class="text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" onclick="navigator.clipboard.writeText(window.location.href);alert('URL Copied!');">Copy URL</button> </p>
+                <p class="leading-7  text-white-400">ID: {{ url_id }} <button class="text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-green-600 rounded " onclick="navigator.clipboard.writeText(window.location.href);alert('URL Copied!');">Copy URL</button> </p>
             </div>
              <div class="flex flex-col text-center w-full text-wrap">
-                <p class="leading-7 text-lg text-white-400 w-auto text-wrap items-center">
-                    <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/download/{{ url_id }}">Download as {{ ext }}</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/">Create Another</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/{{ url_id }}/raw">View Raw</a>
-                    <button id="copy-content-btn" class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg">
+                <p class="leading-7 text-white-400 w-auto text-wrap items-center">
+                    <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded" href="/download/{{ url_id }}">Download as {{ ext }}</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded" href="/">Create Another</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded" href="/{{ url_id }}/raw">View Raw</a>
+                    <button id="copy-content-btn" class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded">
                             Copy 
                     </button>
                 </p>
                 {% if edit and not is_owner %}
                 <br>
-                <p class="leading-7 text-lg text-white-400 mt-2">This clip is editable by its owner.</p>
+                <p class="leading-7  text-white-400 mt-2">This clip is editable by its owner.</p>
                 {% endif %}
             </div>
             <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
@@ -72,7 +72,7 @@
                                 {% endif %}
                       
                             <button id="update-btn" type="button"
-                                class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 text-center focus:outline-none hover:bg-green-600 rounded text-lg">
+                                class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 text-center focus:outline-none hover:bg-green-600 rounded ">
                                 Update
                             </button>
                          {% endif %}
@@ -81,12 +81,12 @@
                 </div>
             </div>
             <div class="flex flex-col text-center w-full mb-12">
-                <p class="leading-7 text-lg text-white-400"> Created: {{ time }} UTC</p>
+                <p class="leading-7  text-white-400"> Created: {{ time }} UTC</p>
                 {% if edit and update %}
-                <p class="leading-7 text-lg text-white-400"> Updated: {{ update }} UTC</p>
+                <p class="leading-7  text-white-400"> Updated: {{ update }} UTC</p>
                 {% endif %}
                 {% if time_left %}
-                <p class="leading-7 text-lg text-white-400"> Time Left until Expiration: {{ time_left }}</p>
+                <p class="leading-7  text-white-400"> Time Left until Expiration: {{ time_left }}</p>
                 {% endif %}
             </div>
         </div>

--- a/templates/clip.html
+++ b/templates/clip.html
@@ -18,12 +18,12 @@
                 <p class="lg:w-2/3 mx-auto leading-relaxed text-base">{{ error }}</p>
             </div>
             {% endif %}
-            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
+            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
-                    <label for="clip_passwd" class="leading-7 text-l text-gray-400">Enter Password</label>
+                    <label for="clip_passwd" class="leading-7 text-lg text-gray-400">Enter Password</label>
                     <form action="/{{ url_id }}" method="post">
-                        <input type="password" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-800 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
-                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Go</button>
+                        <input type="password" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-800 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
+                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Go</button>
                     </form>
                 </div>
             </div>
@@ -36,35 +36,43 @@
         <div class="container px-5 py-24 mx-auto">
             <div class="flex flex-col text-center w-full mb-12">
                 <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-white">{{ name }}</h1>
-                <p class="leading-7 text-l text-white-400">ID: {{ url_id }} <button class="text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" onclick="navigator.clipboard.writeText(window.location.href);alert('URL Copied!');">Copy URL</button> </p>
+                <p class="leading-7 text-lg text-white-400">ID: {{ url_id }} <button class="text-white bg-green-500 border-0 py-1 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" onclick="navigator.clipboard.writeText(window.location.href);alert('URL Copied!');">Copy URL</button> </p>
             </div>
-            <div class="flex flex-col text-center w-full text-wrap">
-                <p class="leading-7 text-l text-white-400 w-auto text-wrap items-center">
-                    <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/download/{{ url_id }}">Download as {{ ext }}</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/">Create Another</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 roundedtext-lg" href="/{{ url_id }}/raw">View Raw</a>
+             <div class="flex flex-col text-center w-full text-wrap">
+                <p class="leading-7 text-lg text-white-400 w-auto text-wrap items-center">
+                    <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/download/{{ url_id }}">Download as {{ ext }}</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/">Create Another</a> <a class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg" href="/{{ url_id }}/raw">View Raw</a>
+                    <button id="copy-content-btn" class="inline-flex items-center rounded text-white bg-green-500 border-0 py-2 px-4 focus:outline-none hover:bg-green-600 rounded text-lg">
+                            Copy 
+                    </button>
                 </p>
                 {% if edit and not is_owner %}
                 <br>
-                <p class="leading-7 text-l text-white-400 mt-2">This clip is editable by its owner.</p>
+                <p class="leading-7 text-lg text-white-400 mt-2">This clip is editable by its owner.</p>
                 {% endif %}
             </div>
-            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
+            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
                     {% if edit %}
                     <form action="/update/{{ url_id }}" method="post">
                         <textarea name="clip_text" id="clip_text"
-                            class="w-full mt-4 bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap"
-                            rows="4"
+                            class="w-full mt-4 bg-zinc-900 bg-opacity-40 rounded border outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap"
+                            rows="8" 
                             oninput="this.style.height='auto';let min=8*16;let max=30*16;let h=this.scrollHeight;this.style.height=Math.min(Math.max(h,min),max)+'px';">{{ text }}
                         </textarea>
-                            {% if is_owner %}
-                                {% if passwd %}
+                        
+                            {% if is_owner %}                                      
+                                {% if passwd2 %}
                                     <input type="password"
+                                        id="clip_passwd"
                                         name="clip_passwd"
                                         placeholder="Clip password"
                                         class="w-full mt-2 bg-zinc-900 text-white border border-gray-700 rounded px-3 py-2"
-                                        required> 
-                                {% endif %}                             
-                            <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">
+                                        style="display:none;"
+                                    >
+                                {% endif %}
+                      
+                            <button id="update-btn" type="button"
+                                class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 text-center focus:outline-none hover:bg-green-600 rounded text-lg">
                                 Update
                             </button>
                          {% endif %}
@@ -73,15 +81,45 @@
                 </div>
             </div>
             <div class="flex flex-col text-center w-full mb-12">
-                <p class="leading-7 text-l text-white-400"> Created: {{ time }} UTC</p>
+                <p class="leading-7 text-lg text-white-400"> Created: {{ time }} UTC</p>
                 {% if edit and update %}
-                <p class="leading-7 text-l text-white-400"> Updated: {{ update }} UTC</p>
+                <p class="leading-7 text-lg text-white-400"> Updated: {{ update }} UTC</p>
                 {% endif %}
                 {% if time_left %}
-                <p class="leading-7 text-l text-white-400"> Time Left until Expiration: {{ time_left }}</p>
+                <p class="leading-7 text-lg text-white-400"> Time Left until Expiration: {{ time_left }}</p>
                 {% endif %}
             </div>
         </div>
     </section>
     {% endif %}
+<script>
+const updateBtn = document.getElementById("update-btn");
+const passField = document.getElementById("clip_passwd");
+
+if (updateBtn) {
+    updateBtn.addEventListener("click", () => {
+        if (!passField) {
+            updateBtn.closest("form").submit();
+            return;
+        }
+
+        if (passField.style.display === "none") {
+            passField.style.display = "block";
+            passField.focus();
+            updateBtn.innerText = "Confirm Update";
+            return;
+        }
+
+        if (passField.value.trim() === "") {
+            alert("Please enter the clip password");
+            passField.focus();
+            return;
+        }
+
+        updateBtn.closest("form").submit();
+    });
+}
+</script>
+
+
 {% endblock %}

--- a/templates/clip.html
+++ b/templates/clip.html
@@ -49,19 +49,27 @@
             </div>
             <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
-                    {% if edit and is_owner %}
+                    {% if edit %}
                     <form action="/update/{{ url_id }}" method="post">
-                        <textarea name="clip_text" id="clip_text" class="w-full mt-4 bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap" rows="4" oninput="this.style.height = 'auto'; let min = 8 * 16; let max = 30 * 16; let scrh = this.scrollHeight; if (scrh < min) { this.style.height = min + 'px'; } else if (scrh > max) { this.style.height = max + 'px'; } else { this.style.height = scrh + 'px'; } ">{{ text }}</textarea>
-                        <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Update</button>
+                        <textarea name="clip_text" id="clip_text"
+                            class="w-full mt-4 bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap"
+                            rows="4"
+                            oninput="this.style.height='auto';let min=8*16;let max=30*16;let h=this.scrollHeight;this.style.height=Math.min(Math.max(h,min),max)+'px';">{{ text }}
+                        </textarea>
+                            {% if is_owner %}
+                                {% if passwd %}
+                                    <input type="password"
+                                        name="clip_passwd"
+                                        placeholder="Clip password"
+                                        class="w-full mt-2 bg-zinc-900 text-white border border-gray-700 rounded px-3 py-2"
+                                        required> 
+                                {% endif %}                             
+                            <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">
+                                Update
+                            </button>
+                         {% endif %}
                     </form>
-                    <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" onclick="navigator.clipboard.writeText(document.getElementById('clip_text').value); alert('Text Copied!');">Copy Text</button>
-                    {% else %}
-                        <pre>
-                        <code name="clip_text" class="w-full bg-zinc-900 bg-opacity-40 roundedborder outline-dashed py-1 px-3 leading-8 ubuntu-mono-regular text-wrap">{{ text }}</code>
-                        </pre>
-                        <button class="text-white bg-green-500 border-0 mt-2 mb-2 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" onclick="navigator.clipboard.writeText(document.querySelector('code[name=clip_text]').innerText); alert('Text Copied!');">Copy Text</button>
                     {% endif %}
-                    </pre>
                 </div>
             </div>
             <div class="flex flex-col text-center w-full mb-12">

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -34,8 +34,8 @@
                 <td class="px-4 py-3">{{ d["clip_time"] }} UTC</td>
                 <td class="px-4 py-3">{{ d["is_editable"] | stat }}</td>
                 <td class="px-4 py-3">{{ d["is_unlisted"] | stat }}</td>
-                <td class="px-4 py-3"><a class="text-white border-2 py-2 px-4 focus:outline-none roundedtext-lg" href="/{{ d["clip_url"] }}">Go</a></td>
-                <td class="px-4 py-3"><a class="text-white border-2 py-2 px-4 focus:outline-none roundedtext-lg" href="/delete/{{ d["clip_url"] }}">Delete</a></td>
+                <td class="px-4 py-3"><a class="text-white border-2 py-2 px-4 focus:outline-none rounded text-lg" href="/{{ d["clip_url"] }}">Go</a></td>
+                <td class="px-4 py-3"><a class="text-white border-2 py-2 px-4 focus:outline-none rounded text-lg" href="/delete/{{ d["clip_url"] }}">Delete</a></td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@ Share Code or Text Instantly
                 
                 </div>
 
-                <div class="text-white border-0 py-2 px-8 focus:outline-none bg-gray-800 rounded text-lg">
+                <div class="text-white border-0 py-2 px-8 focus:outline-none bg-gray-800 rounded ">
                   <h1 class="leading-7 text-white">Optionals</h1>
                   <div class="relative">
                     <label for="clip_alias" class="leading-7 text-sm text-gray-400">Custom URL Alias</label>
@@ -66,13 +66,13 @@ Share Code or Text Instantly
                   >
                     
                     <div class="check-box-container flex text-center mt-1">
-                      <label for="clip_edit" class="leading-7 text-lg text-gray-400">Make Editable? (Login)</label>
+                      <label for="clip_edit" class="leading-7  text-gray-400">Make Editable? (Login)</label>
                       <label class="inline-flex items-center cursor-pointer">
                         <input type="checkbox" name="clip_edit" id="clip_edit" class="sr-only peer">
                         <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
                         <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300"></span> 
                       </label>
-                      <label for="clip_disp" class="leading-7 text-lg text-gray-400">Set Unlisted? </label>
+                      <label for="clip_disp" class="leading-7  text-gray-400">Set Unlisted? </label>
                       <label class="inline-flex items-center cursor-pointer">
                         <input type="checkbox" name="clip_disp" id="clip_disp" class="sr-only peer">
                         <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
@@ -82,7 +82,7 @@ Share Code or Text Instantly
                   </div>
                 </div>
                 <br>
-                <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Save</button>
+                <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded " type="submit">Save</button>
               </form>
             </div>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@ Share Code or Text Instantly
             <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-white">Create a Clip</h1>
             <p class="lg:w-2/3 mx-auto leading-relaxed text-base">Dump your code or whatever you want.</p>
           </div>
-          <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
+          <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
             <div class="relative sm:mb-0 flex-grow w-full">
               <label for="clip_name" class="leading-7 text-sm text-gray-400">Enter Title</label>
               <form action="/" method="post" enctype="multipart/form-data">
@@ -28,16 +28,16 @@ Share Code or Text Instantly
                 
                 </div>
 
-                <div class="text-white border-0 py-2 px-8 focus:outline-none bg-gray-800 roundedtext-lg">
+                <div class="text-white border-0 py-2 px-8 focus:outline-none bg-gray-800 rounded text-lg">
                   <h1 class="leading-7 text-white">Optionals</h1>
                   <div class="relative">
                     <label for="clip_alias" class="leading-7 text-sm text-gray-400">Custom URL Alias</label>
-                    <input type="text" id="clip_alias" name="clip_alias" class="w-full bg-gray-700 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" placeholder="Custom-Alias (a-z A-Z 0-9 -_ only)" autocapitalize="off" autocomplete="off" maxlength="12" minlength="4">
+                    <input type="text" id="clip_alias" name="clip_alias" class="w-full bg-gray-700 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" placeholder="Custom-Alias (a-z A-Z 0-9 -_ only)" autocapitalize="off" autocomplete="off" maxlength="12" minlength="4">
                     <label for="clip_passwd" class="leading-7 text-sm text-gray-400">Create a Password Protected Clip</label>
-                    <input type="text" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-700 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" placeholder="Enter Password" autocapitalize="off" autocomplete="off">
+                    <input type="text" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-700 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" placeholder="Enter Password" autocapitalize="off" autocomplete="off">
                     <label class="leading-7 text-sm text-gray-400">Using Password also enables E2EE.</label><br>
                     <label class="leading-7 text-sm text-gray-400" for="clip_delete">Remove After:</label>
-                    <select name="clip_delete" id="clip_delete" class="w-full bg-gray-700 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-2 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                    <select name="clip_delete" id="clip_delete" class="w-full bg-gray-700 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-2 px-3 leading-8 transition-colors duration-200 ease-in-out">
                       <option value="never">Never</option>
                       <option value="day">1 Day</option>
                       <option value="week">1 Week</option>
@@ -66,13 +66,13 @@ Share Code or Text Instantly
                   >
                     
                     <div class="check-box-container flex text-center mt-1">
-                      <label for="clip_edit" class="leading-7 text-l text-gray-400">Make Editable? (Login)</label>
+                      <label for="clip_edit" class="leading-7 text-lg text-gray-400">Make Editable? (Login)</label>
                       <label class="inline-flex items-center cursor-pointer">
                         <input type="checkbox" name="clip_edit" id="clip_edit" class="sr-only peer">
-                        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 8920dedcb8f64121adaffd541e2ec130after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
+                        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
                         <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300"></span> 
                       </label>
-                      <label for="clip_disp" class="leading-7 text-l text-gray-400">Set Unlisted? </label>
+                      <label for="clip_disp" class="leading-7 text-lg text-gray-400">Set Unlisted? </label>
                       <label class="inline-flex items-center cursor-pointer">
                         <input type="checkbox" name="clip_disp" id="clip_disp" class="sr-only peer">
                         <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
@@ -82,7 +82,7 @@ Share Code or Text Instantly
                   </div>
                 </div>
                 <br>
-                <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Save</button>
+                <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Save</button>
               </form>
             </div>
           </div>

--- a/templates/info.html
+++ b/templates/info.html
@@ -20,7 +20,7 @@
             <p class="leading-relaxed text-white">
                 The developer maybe referred as I, we, our. ClipBin maybe referred by name, or simply 'this'.
             </p>
-            <ul class="list-disc list-inside text-l">
+            <ul class="list-disc list-inside text-lg">
                 <li><b>By using this service you agree to not use this for any illegal purpose.</b></li>
                 <li>This is an open source service for which the source code can be found on GitHub. Navigate to <a href="https://github.com/Alight659/ClipBin" class="hover:bg-gray-700 underline">https://github.com/Alight659/ClipBin</a></li>
                 <li>You are free to self-host this in whatever way you want. The code is released under <a href="https://github.com/Alight659/ClipBin/blob/main/LICENSE" class="underline" target="_blank">MIT License</a>.</li>

--- a/templates/info.html
+++ b/templates/info.html
@@ -20,7 +20,7 @@
             <p class="leading-relaxed text-white">
                 The developer maybe referred as I, we, our. ClipBin maybe referred by name, or simply 'this'.
             </p>
-            <ul class="list-disc list-inside text-lg">
+            <ul class="list-disc list-inside ">
                 <li><b>By using this service you agree to not use this for any illegal purpose.</b></li>
                 <li>This is an open source service for which the source code can be found on GitHub. Navigate to <a href="https://github.com/Alight659/ClipBin" class="hover:bg-gray-700 underline">https://github.com/Alight659/ClipBin</a></li>
                 <li>You are free to self-host this in whatever way you want. The code is released under <a href="https://github.com/Alight659/ClipBin/blob/main/LICENSE" class="underline" target="_blank">MIT License</a>.</li>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -69,7 +69,7 @@
               <button
                 id="theme-toggle"
                 type="button"
-                class="inline-flex items-center focus:outline-none rounded text-base mt-4 md:mt-0 md:ml-4 p-2 hover: text-white"
+                class="inline-flex items-center focus:outline-none rounded text-base mt-4 md:mt-0 md:ml-4 p-2 hover:text-white"
                 aria-label="Toggle theme"
               >
                 <i id="theme-toggle-icon" class="fa-solid fa-moon" aria-hidden="true"></i>
@@ -147,7 +147,7 @@
           <span class="mr-1">|</span>
           <a
             href="/feedback"
-            class="text-gray-500 ml-1Terms and Privacy"
+            class="text-gray-500 ml-1"
             rel="noopener noreferrer"
             >Feedback</a
           >

--- a/templates/passwd.html
+++ b/templates/passwd.html
@@ -11,12 +11,12 @@
                 <p class="lg:w-2/3 mx-auto leading-relaxed text-base">{{ error }}</p>
             </div>
             {% endif %}
-            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4sm:space-y-0 space-y-4">
+            <div class="flex lg:w-2/3 w-full sm:flex-row flex-col mx-auto px-8 sm:px-0 items-end sm:space-x-4 sm:space-y-0 space-y-4">
                 <div class="relative sm:mb-0 flex-grow w-full">
-                    <label for="clip_passwd" class="leading-7 text-l text-gray-400">Enter Password</label>
+                    <label for="clip_passwd" class="leading-7 text-lg text-gray-400">Enter Password</label>
                     <form action="/download/{{ url_id }}" method="post">
-                        <input type="password" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-800 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
-                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Go</button>
+                        <input type="password" id="clip_passwd" name="clip_passwd" class="w-full bg-gray-800 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
+                        <button class="text-white bg-green-500 border-0 py-2 px-8 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Go</button>
                     </form>
                 </div>
             </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -14,8 +14,8 @@
                 <div class="relative sm:mb-0 flex-grow w-full">
                     <label for="clip_info" class="leading-7 text-sm text-gray-400">Enter Clip Name or URL Id</label>
                     <form action="/clip" method="post">
-                        <input type="text" id="clip_info" name="clip_info" class="w-full bg-gray-800 bg-opacity-40 roundedborder border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparenttext-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
-                        <button class="text-white bg-green-500 border-0 py-2 px-8 mt-2 focus:outline-none hover:bg-green-600 roundedtext-lg" type="submit">Go</button>
+                        <input type="text" id="clip_info" name="clip_info" class="w-full bg-gray-800 bg-opacity-40 rounded border border-gray-700 focus:border-green-500 focus:ring-2 focus:ring-green-900 focus:bg-transparent text-base outline-none text-gray-100 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" autocapitalize="off" autocomplete="off" autofocus>
+                        <button class="text-white bg-green-500 border-0 py-2 px-8 mt-2 focus:outline-none hover:bg-green-600 rounded text-lg" type="submit">Go</button>
                     </form>
                 </div>
             </div>
@@ -38,7 +38,7 @@
                             <td class="px-4 py-3">{{ d["clip_name"] }}</td>
                             <td class="px-4 py-3">{{ d["clip_url"] }}</td>
                             <td class="px-4 py-3">{{ d["clip_time"] }}</td>
-                            <td class="px-4 py-3"><a class="text-white border-2 py-2 px-8 focus:outline-none roundedtext-lg" href="/{{ d["clip_url"] }}">Go</a></td>
+                            <td class="px-4 py-3"><a class="text-white border-2 py-2 px-8 focus:outline-none rounded text-lg" href="/{{ d["clip_url"] }}">Go</a></td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
---
name: Pull Request
about: Propose changes to the codebase
title: "[PR]: Fix encrypted clip corruption on update"
labels: [bug, security]
---

Fixes https://github.com/alight659/ClipBin/issues/85


---

##  Description

This pull request fixes a critical bug where **password-protected clips were being saved as plaintext when edited**.

Previously, when a protected clip was updated:
- The old encrypted data was overwritten with raw text.
- This corrupted the stored ciphertext.
- Future reads caused `TypeError` because `decrypt()` expected bytes but received a string.

This patch ensures:
- Encrypted clips are **always decrypted → compared → re-encrypted** before saving.
- The clip password is **required and verified** before any update.
- Unprotected clips continue to be stored as plaintext.

This preserves ClipBin’s **zero-knowledge encryption model** and prevents data corruption.

---

##  Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

---

##  How Has This Been Tested?

The following scenarios were manually tested:

| Scenario | Result |
|--------|--------|
Create encrypted clip | Stored as encrypted bytes |
Edit encrypted clip | Re-encrypted correctly |
Edit with wrong password | Blocked |
Edit without password | Blocked |
Edit unprotected clip | Stored as plaintext |
View after edit | Works |
Download after edit | Works |
Raw endpoint | Works |
API access | Works |

### Reproduction Steps

1. Create a clip with a password.
2. Open it using the correct password.
3. Edit and submit the new content.
4. Reload the page.
5. View raw/download/API — no crash occurs.

---

##  Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have commented my code where encryption logic is involved
- [x] My changes generate no new warnings
- [x] I have tested encrypted and unencrypted update flows
- [x] No regressions introduced
- [x] No downstream changes required




---

##  Screenshots

# Old 
https://github.com/user-attachments/assets/f6c376ba-1bf7-4d82-a2be-978b0dbb467f


https://github.com/user-attachments/assets/56a103cc-93ff-44c6-8a8c-7d8c84aa30f3
# After Update 

https://github.com/user-attachments/assets/ee6df6c5-12c7-4d13-8b54-5be3a7e5d61a


https://github.com/user-attachments/assets/6a36ef58-a0da-4a2a-bee4-5297a3c76ee2

